### PR TITLE
fix 0.2.3: Add typer as missing dependency for transformers

### DIFF
--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -13,7 +13,7 @@ source:
   sha256: f76423630ae3ac4e090cb38ce1e30e7bcc69b3dee4d22d94353944386a4c6f18
 
 build:
-  number: 0
+  number: 1
   skip:
     - win
   script:
@@ -79,6 +79,7 @@ requirements:
     - tiktoken
     - pytorch >=1.10.0
     - transformers >=4.38.0
+    - typer
     - typing_extensions >=4.9.0
     - if: linux and x86_64
       then: triton


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

The build for v0.2.3 failed because typer is now a dependency in the latest transformers. Ideally this would be added to the transformers-feedstock as a dependency, but it might be a while before that it added.